### PR TITLE
add largeImageKey

### DIFF
--- a/src/discordrpcplugin.cpp
+++ b/src/discordrpcplugin.cpp
@@ -145,6 +145,7 @@ void DiscordRpcPlugin::updateStatus()
     QByteArray state = formatText(m_config->stateText);
     discordPresence.details = details;
     discordPresence.state = state;
+    discordPresence.largeImageKey = "kate";
 
     Discord_UpdatePresence(&discordPresence);
 }


### PR DESCRIPTION
If `largeImageKey` is not set, it shows a controller icon in the **Active Now** section in friends page.

![Screenshot_2025-06-22_09-39-03](https://github.com/user-attachments/assets/730402b1-7c90-469f-a21f-0e535b575c83)

The image on left is `largeImageKey` and the one on top-right corner is the Application's icon (i think).
You should upload the large image in Rich Presence -> Art Assets

I exported the scalable svg with inkscape to a 1024x1024 png which is recommended by discord.
![1024-apps-kate](https://github.com/user-attachments/assets/eb9b4137-5af7-45e5-9a30-d0674af89370)
